### PR TITLE
Fix ESLint imports with TypeScript

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -205,7 +205,7 @@
     "css-loader": "6.7.2",
     "dotenv": "16.0.3",
     "eslint": "8.29.0",
-    "eslint-import-resolver-typescript": "3.5.2",
+    "eslint-import-resolver-typescript": "^3.5.2",
     "eslint-plugin-cypress": "2.12.1",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-prettier": "4.2.1",

--- a/core/yarn.lock
+++ b/core/yarn.lock
@@ -5720,7 +5720,7 @@ eslint-import-resolver-node@^0.3.6:
     debug "^3.2.7"
     resolve "^1.20.0"
 
-eslint-import-resolver-typescript@3.5.2:
+eslint-import-resolver-typescript@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.2.tgz#9431acded7d898fd94591a08ea9eec3514c7de91"
   integrity sha512-zX4ebnnyXiykjhcBvKIf5TNvt8K7yX6bllTRZ14MiurKPjDpCAZujlszTdB8pcNXhZcOf+god4s9SjQa5GnytQ==


### PR DESCRIPTION
Adds the package eslint-import-resolver-typescript to dev dependencies. This dependency helps ESLint resolve imports for TypeScript that use **path mappings**. This package is most useful when developing in IDEs that use the official ESLint extensions