### PR TITLE
feat: remove required name in media_library config

### DIFF
--- a/core/src/constants/configSchema.tsx
+++ b/core/src/constants/configSchema.tsx
@@ -170,7 +170,7 @@ function getConfigSchema() {
           name: { type: 'string', examples: ['uploadcare'] },
           config: { type: 'object' },
         },
-        required: ['name'],
+        required: [],
       },
       slug: {
         type: 'object',


### PR DESCRIPTION
name is only required to configure an external media library, but the media_library config can be used without a name to configure the max file size for example.

See in `core/src/mediaLibrary.ts` the `isExternalMediaLibraryConfig` function.