### PR TITLE
feat: GitLab LFS Support

### DIFF
--- a/packages/core/src/backends/gitlab/API.ts
+++ b/packages/core/src/backends/gitlab/API.ts
@@ -221,7 +221,7 @@ export default class API {
     const fetchContent = async () => {
       const content = await this.request({
         url: `${this.repoURL}/repository/files/${encodeURIComponent(path)}/raw`,
-        params: { ref: branch },
+        params: { ref: branch, lfs: 'true' }, // lfs=true means that even if the file is stored in LFS, return the content
         cache: 'no-store',
       }).then<Blob | string>(parseText ? this.responseToText : this.responseToBlob);
       return content;

--- a/packages/docs/content/docs/gitlab-backend.mdx
+++ b/packages/docs/content/docs/gitlab-backend.mdx
@@ -79,3 +79,7 @@ backend: {
 },
 ```
 </CodeTabs>
+
+## Git Large File Storage (LFS)
+
+The GitLab backend **does** support [git-lfs](https://git-lfs.github.com/).


### PR DESCRIPTION
Added the `?lfs=true` flag to GitLab file requests
This means, that if a file is stored in LFS, return the content See https://github.com/netlify/netlify-cms/issues/3704 for the upstream issue.
Any non-LFS Repos are not affected by this change. Here are the [GitLab Docs on this feature](https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository) to partially proof this.

I know that this is a bugfix, which is not on your roadmap (nor does it have an issue), but I think this should be an uncontroversial bugfix of the original project 😉

# Screenshots
- Previous Behaviour (with LFS **enabled**):
  ![image](https://user-images.githubusercontent.com/26258709/212394182-3683ffd9-7089-4588-8852-a3f6a39a4f22.png)
- Current Behaviour (with LFS **disabled**):  
  ![image](https://user-images.githubusercontent.com/26258709/212393306-d8c23977-d50a-48e7-a4b7-9688d5c8151c.png)
- Current Behaviour (with LFS **enabled**):    
  ![image](https://user-images.githubusercontent.com/26258709/212395641-7882939f-388a-42c0-87ab-26d2b7950205.png)

