### PR TITLE
docs: Update bundling documentation with an example using Astro

### DIFF
--- a/packages/docs/content/docs/add-to-your-site-bundling.mdx
+++ b/packages/docs/content/docs/add-to-your-site-bundling.mdx
@@ -12,17 +12,23 @@ To get started you need to install Static CMS via a package manager and save it 
 
 ```bash
 // npm
-npm install @staticcms/core
+npm install @staticcms/core@next
 
 // yarn
-yarn add @staticcms/core
+yarn add @staticcms/core@next
 ```
 
-Then import it (assuming your project has tooling for imports):
+Then create a new route for your project (for instance at `/admin`), and import Static CMS:
 
 ```js
 import CMS from '@staticcms/core';
-import config from './config';
+```
+
+The the default export is a _CMS_ object, which has an `init` method that takes an object with a `config` attribute. The `config` attribute is an object representing the [configuration options](docs/configuration-options). You can use destructuring assigment syntax as shorthand: 
+
+```js
+import CMS from '@staticcms/core';
+import config from './config.js';
 
 // Initialize the CMS object
 CMS.init({ config });
@@ -32,9 +38,24 @@ CMS.registerPreviewTemplate('my-template', MyTemplate);
 
 **Note**: Wherever you initialize Static CMS (via `CMS.init()`), it takes over the current page. Make sure you only run the initialization code on your CMS page.
 
+If the CMS object is initialized without being passed an object with a valid config attribute, it will try to fetch and read a `config.yml` or `config.js` file, via http, within the same path where the CMS resides (`/admin/config.<js/yml>`).
+
+```js
+import CMS from '@staticcms/core';
+
+// Initialize the CMS object
+CMS.init();
+// Now the registry is available via the CMS object.
+CMS.registerPreviewTemplate('my-template', MyTemplate);
+```
+
+**Note**: Because `config.<js/yml>` is requested via http, make sure `<siteurl>/admin/config.<js/yml>` exists as an endpoint on your build. If the file is not placed in the public folder, this might not be the default behaviour for your framework.
+
+Make sure the file containing the CMS object will be built as a page, with `@staticcms/core` bundled, and the code including `CMS.init()` being run inside a script tag. This is what might take some time, as it will be done differently based on your framework. Check your framework's documentation for further details. 
+
 ## Configuration
 
-Configuration is different for every site, so we'll break it down into parts. Add all the code snippets in this section to your `admin/config.js` file (which is passed into the `CMS.init({ config })` call). Alternatively, you can use a yaml file (`admin/config.yml`) instead of a javascript file.
+Configuration is different for every site, so we'll break it down into parts. Add all the code snippets in this section to your `admin/config.js` file (which is passed into the `CMS.init({ config })` call).
 
 ### Backend
 

--- a/packages/docs/content/docs/add-to-your-site-bundling.mdx
+++ b/packages/docs/content/docs/add-to-your-site-bundling.mdx
@@ -24,7 +24,7 @@ Then create a new route for your project (for instance at `/admin`), and import 
 import CMS from '@staticcms/core';
 ```
 
-The the default export is a _CMS_ object, which has an `init` method that takes an object with a `config` attribute. The `config` attribute is an object representing the [configuration options](docs/configuration-options). You can use destructuring assigment syntax as shorthand: 
+The default export is a _CMS_ object, which has an `init` method that takes an object with a `config` attribute. The `config` attribute is an object representing the [configuration options](docs/configuration-options). You can use destructuring assigment syntax as shorthand: 
 
 ```js
 import CMS from '@staticcms/core';
@@ -114,7 +114,7 @@ export function get() {
 }
 ```
 
-Since Static CMS uses react to components for customization, you can optionally add the react integration to your Astro project. This will add autocompletion when importing and using react components. Altough keep in mind that jsx/tsx syntax cannot be used inside script tags.
+Since Static CMS uses react components for customization, you can optionally add the react integration to your Astro project. This will add autocompletion when importing and using react components. Altough keep in mind that jsx/tsx syntax cannot be used inside script tags.
 
 
 ```bash

--- a/packages/docs/content/docs/add-to-your-site-bundling.mdx
+++ b/packages/docs/content/docs/add-to-your-site-bundling.mdx
@@ -28,7 +28,7 @@ The default export is a _CMS_ object, which has an `init` method that takes an o
 
 ```js
 import CMS from '@staticcms/core';
-import config from './config.js';
+import config from './config';
 
 // Initialize the CMS object
 CMS.init({ config });
@@ -38,7 +38,7 @@ CMS.registerPreviewTemplate('my-template', MyTemplate);
 
 **Note**: Wherever you initialize Static CMS (via `CMS.init()`), it takes over the current page. Make sure you only run the initialization code on your CMS page.
 
-If the CMS object is initialized without being passed an object with a valid config attribute, it will try to fetch and read a `config.yml` or `config.js` file, via http, within the same path where the CMS resides (`/admin/config.<js/yml>`).
+If the CMS object is initialized without being passed an object with a valid config attribute, it will try to fetch and read a `config.yml` file, via http, within the same path where the CMS resides (`/admin/config.yml`).
 
 ```js
 import CMS from '@staticcms/core';
@@ -49,82 +49,9 @@ CMS.init();
 CMS.registerPreviewTemplate('my-template', MyTemplate);
 ```
 
-**Note**: Because `config.<js/yml>` is requested via http, make sure `<siteurl>/admin/config.<js/yml>` exists as an endpoint on your build. If the file is not placed in the public folder, this might not be the default behaviour for your framework.
+**Note**: Because `config.yml` is requested via http, make sure `<siteurl>/admin/config.yml` exists as an endpoint on your build. If the file is not placed in the public folder, this might not be the default behaviour for your static site generator.
 
-Make sure the file containing the CMS object will be built as a page, with `@staticcms/core` bundled, and the code including `CMS.init()` being run inside a script tag. This is what might take some time, as it will be done differently based on your framework. Check your framework's documentation for further details. 
-
-### Example using [Astro](https://astro.build)
-
-Create an _Astro component_ `src/pages/admin/index.astro`, with HTML boilerplate:
-
-```html
----
-
----
-<!doctype html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Content Manager</title>
-</head>
-<body>
-  
-</body>
-</html>
-```
-
-By default, Astro will bundle all npm and local import statements from script tags, to the browser. Add a script tag:
-
-```html
----
-
----
-<!doctype html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Content Manager</title>
-</head>
-<body>
-  
-</body>
-</html>
-<script>
-  import CMS from '@staticcms/core'
- 
-  CMS.init();
-</script>
-```
-
-Now you have to add a config file in `src/pages/admin/config.yml` (alternatively `.js`). Static CMS will look for a config at `<siteurl>/admin/config.yml`.
-Because this file is not inside the public folder, Astro will not serve it statically. Therefore, an endpoint which returns the file needs to be created.
-
-In Astro this is done by creating a `src/pages/admin/config.yml.js` file. See [Astro documentation](https://docs.astro.build/en/core-concepts/endpoints/#static-file-endpoints) for details.
-
-The endpoint should return a body with the config inside:
-
-```js
-import config from './config.yml?raw' //vite's "?raw" suffix imports the asset as a string
-export function get() {
-    return {
-        body: config
-    }
-}
-```
-
-Since Static CMS uses react components for customization, you can optionally add the react integration to your Astro project. This will add autocompletion when importing and using react components. Altough keep in mind that jsx/tsx syntax cannot be used inside script tags.
-
-
-```bash
-# Using NPM
-npx astro add react
-# Using Yarn
-yarn astro add react
-# Using PNPM
-pnpm astro add react
-```
+Make sure the file containing the CMS object will be built as a page, with `@staticcms/core` bundled, and the code including `CMS.init()` being run inside a script tag. This is what might take some time, as it will be done differently based on your static site generator. Check your static site generators's documentation for further details. 
 
 ## Configuration
 

--- a/packages/docs/content/docs/add-to-your-site-bundling.mdx
+++ b/packages/docs/content/docs/add-to-your-site-bundling.mdx
@@ -12,10 +12,10 @@ To get started you need to install Static CMS via a package manager and save it 
 
 ```bash
 // npm
-npm install @staticcms/core@next
+npm install @staticcms/core@latest
 
 // yarn
-yarn add @staticcms/core@next
+yarn add @staticcms/core@latest
 ```
 
 Then create a new route for your project (for instance at `/admin`), and import Static CMS:

--- a/packages/docs/content/docs/add-to-your-site-bundling.mdx
+++ b/packages/docs/content/docs/add-to-your-site-bundling.mdx
@@ -53,6 +53,79 @@ CMS.registerPreviewTemplate('my-template', MyTemplate);
 
 Make sure the file containing the CMS object will be built as a page, with `@staticcms/core` bundled, and the code including `CMS.init()` being run inside a script tag. This is what might take some time, as it will be done differently based on your framework. Check your framework's documentation for further details. 
 
+### Example using [Astro](https://astro.build)
+
+Create an _Astro component_ `src/pages/admin/index.astro`, with HTML boilerplate:
+
+```html
+---
+
+---
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Content Manager</title>
+</head>
+<body>
+  
+</body>
+</html>
+```
+
+By default, Astro will bundle all npm and local import statements from script tags, to the browser. Add a script tag:
+
+```html
+---
+
+---
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Content Manager</title>
+</head>
+<body>
+  
+</body>
+</html>
+<script>
+  import CMS from '@staticcms/core'
+ 
+  CMS.init();
+</script>
+```
+
+Now you have to add a config file in `src/pages/admin/config.yml` (alternatively `.js`). Static CMS will look for a config at `<siteurl>/admin/config.yml`.
+Because this file is not inside the public folder, Astro will not serve it statically. Therefore, an endpoint which returns the file needs to be created.
+
+In Astro this is done by creating a `src/pages/admin/config.yml.js` file. See [Astro documentation](https://docs.astro.build/en/core-concepts/endpoints/#static-file-endpoints) for details.
+
+The endpoint should return a body with the config inside:
+
+```js
+import config from './config.yml?raw' //vite's "?raw" suffix imports the asset as a string
+export function get() {
+    return {
+        body: config
+    }
+}
+```
+
+Since Static CMS uses react to components for customization, you can optionally add the react integration to your Astro project. This will add autocompletion when importing and using react components. Altough keep in mind that jsx/tsx syntax cannot be used inside script tags.
+
+
+```bash
+# Using NPM
+npx astro add react
+# Using Yarn
+yarn astro add react
+# Using PNPM
+pnpm astro add react
+```
+
 ## Configuration
 
 Configuration is different for every site, so we'll break it down into parts. Add all the code snippets in this section to your `admin/config.js` file (which is passed into the `CMS.init({ config })` call).


### PR DESCRIPTION
This is my attempt at clarifying the bundling docs. I tried to look at the code, but I didnt understand that much. My understanding of how things work (specifically with regards to loading the config), is mostly from trial and error. This means I might have just written a bunch of garbage, but I tried.

Although since I got bundling to work with Astro, I can say for sure that the provided example is valid.