### PR TITLE
docs: use provided "h" function instead of jsx

### DIFF
--- a/packages/docs/content/docs/custom-icons.mdx
+++ b/packages/docs/content/docs/custom-icons.mdx
@@ -24,7 +24,7 @@ import { faHouse } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import CMS from '@staticcms/core';
 
-CMS.registerIcon('house', () => <FontAwesomeIcon icon={faHouse} size="lg" />);
+CMS.registerIcon('house', () => h(FontAwesomeIcon, {icon=faHouse, size="lg"}));
 ```
 
 ## Usage


### PR DESCRIPTION
This is a suggestion.

In my project, I wasn't able to use JSX syntax where I had this code. I'm thinking this might be the case for a lot of other people as well.
Even if not, the other customizing examples (adding custom previews, adding custom links & pages etc.) do not use JSX syntax, but instead, the provided React.createElement "h" alias.