### PR TITLE
fix: disable commit diff (speedup)

### DIFF
--- a/packages/core/src/backends/gitea/API.ts
+++ b/packages/core/src/backends/gitea/API.ts
@@ -283,7 +283,7 @@ export default class API {
         const result: ReposListCommitsResponse = await this.request(
           `${this.originRepoURL}/commits`,
           {
-            params: { path, sha: this.branch },
+            params: { path, sha: this.branch, stat: "false" },
           },
         );
         const { commit } = result[0];

--- a/packages/core/src/backends/gitea/API.ts
+++ b/packages/core/src/backends/gitea/API.ts
@@ -283,7 +283,7 @@ export default class API {
         const result: ReposListCommitsResponse = await this.request(
           `${this.originRepoURL}/commits`,
           {
-            params: { path, sha: this.branch, stat: "false" },
+            params: { path, sha: this.branch, stat: 'false' },
           },
         );
         const { commit } = result[0];


### PR DESCRIPTION
The commits endpoint of gitea API returns commit diff stats by default, which slows down the requests and has massive impact on overall CMS performance. This PR disables commit stats loading according to Gitea API reference.