### PR TITLE
fix: gitea/refactor file saving

### DIFF
--- a/packages/core/src/backends/gitea/__tests__/API.spec.ts
+++ b/packages/core/src/backends/gitea/__tests__/API.spec.ts
@@ -101,7 +101,7 @@ describe('gitea API', () => {
   });
 
   describe('persistFiles', () => {
-    it('should create a new file', async () => {
+    it('should check if file exists and create a new file', async () => {
       const api = new API({ branch: 'master', repo: 'owner/repo' });
 
       const responses = {
@@ -127,9 +127,13 @@ describe('gitea API', () => {
         newEntry: true,
       });
 
-      expect(api.request).toHaveBeenCalledTimes(1);
+      expect(api.request).toHaveBeenCalledTimes(2);
 
       expect((api.request as jest.Mock).mock.calls[0]).toEqual([
+        '/repos/owner/repo/git/trees/master:content%2Fposts',
+      ]);
+
+      expect((api.request as jest.Mock).mock.calls[1]).toEqual([
         '/repos/owner/repo/contents/content/posts/new-post.md',
         {
           method: 'POST',
@@ -174,10 +178,24 @@ describe('gitea API', () => {
         newEntry: false,
       });
 
-      expect(api.request).toHaveBeenCalledTimes(1);
+      expect(api.request).toHaveBeenCalledTimes(2);
 
       expect((api.request as jest.Mock).mock.calls[0]).toEqual([
         '/repos/owner/repo/git/trees/master:content%2Fposts',
+      ]);
+
+      expect((api.request as jest.Mock).mock.calls[1]).toEqual([
+        '/repos/owner/repo/contents/content/posts/update-post.md',
+        {
+          method: 'PUT',
+          body: JSON.stringify({
+            branch: 'master',
+            content: Base64.encode(entry.dataFiles[0].raw),
+            message: 'commitMessage',
+            sha: 'old-sha',
+            signoff: false,
+          }),
+        },
       ]);
     });
   });

--- a/packages/docs/content/docs/gitea-backend.mdx
+++ b/packages/docs/content/docs/gitea-backend.mdx
@@ -9,13 +9,15 @@ beta: true
 
 For repositories stored on Gitea, the `gitea` backend allows CMS users to log in directly with their Gitea account. Note that all users must have push access to your content repository for this to work.
 
+<Alert severity="warning">Because of the [lack](https://github.com/go-gitea/gitea/issues/14619) of a Gitea API endpoint for multifile commits, when using this backend, separate commits are created for every changed file. Please make sure this is handled correctly by your CI.</Alert>
+
 ## Authentication
 
 Because Gitea requires a server for authentication and Netlify doesn't support Gitea, a custom OAuth provider needs to be used for basic Gitea authentication.
 
 To enable basic Gitea authentication:
 
-1. Setup an own OAuth provider, for example with [scm-oauth](https://github.com/denyskon/scm-oauth-provider).
+1. Setup an own OAuth provider, for example with [Teabag](https://github.com/denyskon/teabag).
 2. Add the following lines to your Static CMS `config` file:
 
 <CodeTabs>


### PR DESCRIPTION
The usage of `forEach()` with asynchronous calls caused a problem where multiple file uploads would run parallel, which causes an error with Gitea unable to create multiple commits simultaneously. 

This PR refactors some parts of the Gitea backend to achieve sequential file saving.

Additional changes:
- fixed unit tests
- updated OAuth provider in docs
- added a warning about the unique behavior of the Gitea backend