### PR TITLE
docs(add-to-your-site-cdn): adds Astro in the SSG | static folder table

### DIFF
--- a/packages/docs/content/docs/add-to-your-site-cdn.mdx
+++ b/packages/docs/content/docs/add-to-your-site-cdn.mdx
@@ -14,7 +14,7 @@ A static `admin` folder contains all Static CMS files, stored at the root of you
 | ------------------------------------------------------- | --------------------- |
 | Jekyll, GitBook                                         | `/` (project root)    |
 | Hugo, Gatsby, Nuxt 2, Gridsome, Zola, Sapper, SvelteKit | `/static`             |
-| Next, Nuxt 3                                            | `/public`             |
+| Next, Nuxt 3, Astro                                     | `/public`             |
 | Hexo, Middleman, Jigsaw                                 | `/source`             |
 | Wyam                                                    | `/input`              |
 | Pelican                                                 | `/content`            |


### PR DESCRIPTION
[Astro project structure](https://docs.astro.build/en/core-concepts/project-structure/) is also using the public folder for static assets.