### PR TITLE
fix(auth): swap popup for new tab

### DIFF
--- a/packages/core/src/lib/auth/netlify-auth.ts
+++ b/packages/core/src/lib/auth/netlify-auth.ts
@@ -128,10 +128,7 @@ class Authenticator {
     if (options.invite_code) {
       url += '&invite_code=' + options.invite_code;
     }
-    this.authWindow = window.open(
-      url,
-      'Netlify Authorization'
-    );
+    this.authWindow = window.open(url, 'Netlify Authorization');
     this.authWindow?.focus();
   }
 

--- a/packages/core/src/lib/auth/netlify-auth.ts
+++ b/packages/core/src/lib/auth/netlify-auth.ts
@@ -18,29 +18,6 @@ export class NetlifyError {
   }
 }
 
-const PROVIDERS = {
-  github: {
-    width: 960,
-    height: 600,
-  },
-  gitlab: {
-    width: 960,
-    height: 600,
-  },
-  gitea: {
-    width: 960,
-    height: 600,
-  },
-  bitbucket: {
-    width: 960,
-    height: 500,
-  },
-  email: {
-    width: 500,
-    height: 400,
-  },
-} as const;
-
 class Authenticator {
   private site_id: string | null;
   private base_url: string;
@@ -55,7 +32,7 @@ class Authenticator {
   }
 
   handshakeCallback(
-    options: { provider?: keyof typeof PROVIDERS },
+    options: { provider?: string | undefined },
     cb: (error: Error | NetlifyError | null, data?: User) => void,
   ) {
     const fn = (e: { data: string; origin: string }) => {
@@ -69,7 +46,7 @@ class Authenticator {
   }
 
   authorizeCallback(
-    options: { provider?: keyof typeof PROVIDERS },
+    options: { provider?: string | undefined },
     cb: (error: Error | NetlifyError | null, data?: User) => void,
   ) {
     const fn = (e: { data: string; origin: string }) => {
@@ -109,7 +86,7 @@ class Authenticator {
 
   authenticate(
     options: {
-      provider?: keyof typeof PROVIDERS;
+      provider?: string | undefined;
       scope?: string;
       login?: boolean;
       beta_invite?: string;
@@ -137,9 +114,6 @@ class Authenticator {
       );
     }
 
-    const conf = PROVIDERS[provider] || PROVIDERS.github;
-    const left = screen.width / 2 - conf.width / 2;
-    const top = screen.height / 2 - conf.height / 2;
     window.addEventListener('message', this.handshakeCallback(options, cb), false);
     let url = `${this.base_url}/${this.auth_endpoint}?provider=${options.provider}&site_id=${siteID}`;
     if (options.scope) {
@@ -156,15 +130,14 @@ class Authenticator {
     }
     this.authWindow = window.open(
       url,
-      'Netlify Authorization',
-      `width=${conf.width}, height=${conf.height}, top=${top}, left=${left}`,
+      'Netlify Authorization'
     );
     this.authWindow?.focus();
   }
 
   refresh(
     options: {
-      provider: keyof typeof PROVIDERS;
+      provider: string;
       refresh_token?: string;
     },
     cb?: (error: Error | NetlifyError | null, data?: User) => void,


### PR DESCRIPTION
Currently, when using the netlify-auth plugin, which is the main one for most backends, the standard behavior is that a popup window is opened when clicking on the authentication button. This leads to some problems:

- many modern browsers tend to block popup windows or at least offer and recommend such a setting
- popup windows lack the standard browser UI, so e.g. password manager extensions often can't be used
- when a specific browser window is set to be always on top and in-focus, popup windows aren't a good solution

This pull request would, if accepted, switch to the standardized `target="_blank"` setting to open a new tab or, optionally, a new window (some browsers allow changing that behavior) instead of a popup window for authentication.