### PR TITLE
fix: Nested collections: fix collection URL variable

### DIFF
--- a/packages/core/src/components/Collection/Collection.tsx
+++ b/packages/core/src/components/Collection/Collection.tsx
@@ -89,10 +89,7 @@ const CollectionView = ({
 
     let url = 'fields' in collection && collection.create ? getNewEntryUrl(collectionName) : '';
     if (url && filterTerm) {
-      url = getNewEntryUrl(collectionName);
-      if (filterTerm) {
-        url = `${url}?path=${filterTerm}`;
-      }
+      url = `${url}?path=${filterTerm}`;
     }
 
     return url;

--- a/packages/core/src/components/Collection/Collection.tsx
+++ b/packages/core/src/components/Collection/Collection.tsx
@@ -91,7 +91,7 @@ const CollectionView = ({
     if (url && filterTerm) {
       url = getNewEntryUrl(collectionName);
       if (filterTerm) {
-        url = `${newEntryUrl}?path=${filterTerm}`;
+        url = `${url}?path=${filterTerm}`;
       }
     }
 


### PR DESCRIPTION
## This Pull Request:
- Fixes what I'm pretty sure is a typo in the memo on determining the collection URL.

## Why is this PR needed?
I ran into the same issue with nested collections as reported in https://github.com/StaticJsCMS/static-cms/issues/63#issuecomment-1438384129

The error points at the line changed in this PR, and after this commit I am able to successfully enter nested collections via the nav tree.