### PR TITLE
fix: Folder collections routes should allow for dir separators

### DIFF
--- a/packages/core/src/components/App/App.tsx
+++ b/packages/core/src/components/App/App.tsx
@@ -199,7 +199,7 @@ const App = ({
             element={<EditorRoute collections={collections} newRecord />}
           />
           <Route
-            path="/collections/:name/entries/:slug"
+            path="/collections/:name/entries/*"
             element={<EditorRoute collections={collections} />}
           />
           <Route

--- a/packages/core/src/components/Editor/EditorRoute.tsx
+++ b/packages/core/src/components/Editor/EditorRoute.tsx
@@ -12,7 +12,7 @@ interface EditorRouteProps {
 }
 
 const EditorRoute = ({ newRecord = false, collections }: EditorRouteProps) => {
-  const { name, slug } = useParams();
+  const { name, '*': slug } = useParams();
   const shouldRedirect = useMemo(() => {
     if (!name) {
       return false;


### PR DESCRIPTION
## This Pull Request:
- Updates the route to match anything following `/entries` as slug, rather than anything up to `/`.

## Why is this PR needed?
- The `path` configuration key allows arbitrary path definitions, which right now, when opened, result in an empty page (since no routes are matching).

Example affected configuration from the docs: 
<img width="319" alt="Screen Shot 2023-03-15 at 18 43 48" src="https://user-images.githubusercontent.com/638323/225459840-8a6c111f-4910-4f96-9439-361ec055fe20.png">
