### PR TITLE
fix(docs): dead links on Bundling page

### DIFF
--- a/packages/docs/content/docs/add-to-your-site-bundling.mdx
+++ b/packages/docs/content/docs/add-to-your-site-bundling.mdx
@@ -4,7 +4,7 @@ title: Bundling
 weight: 5
 ---
 
-This tutorial guides you through the steps for adding Static CMS via a package manager to a site that's built with a common [static site generator](https://www.staticgen.com/). If you want to start form a template, the [Next Template](docs/start-with-a-template) provides a great example of bundling in action.
+This tutorial guides you through the steps for adding Static CMS via a package manager to a site that's built with a common [static site generator](https://www.staticgen.com/). If you want to start form a template, the [Next Template](/docs/start-with-a-template) provides a great example of bundling in action.
 
 ## Installation
 
@@ -24,7 +24,7 @@ Then create a new route for your project (for instance at `/admin`), and import 
 import CMS from '@staticcms/core';
 ```
 
-The default export is a _CMS_ object, which has an `init` method that takes an object with a `config` attribute. The `config` attribute is an object representing the [configuration options](docs/configuration-options). You can use destructuring assignment syntax as shorthand:
+The default export is a _CMS_ object, which has an `init` method that takes an object with a `config` attribute. The `config` attribute is an object representing the [configuration options](/docs/configuration-options). You can use destructuring assignment syntax as shorthand:
 
 ```js
 import CMS from '@staticcms/core';


### PR DESCRIPTION
This PR fixes a couple of broken links I noticed on the Bundling page (https://www.staticcms.org/docs/add-to-your-site-bundling)