### PR TITLE
fix: Nested Folders Feature Routing

### DIFF
--- a/packages/core/src/components/App/App.tsx
+++ b/packages/core/src/components/App/App.tsx
@@ -76,8 +76,8 @@ function CollectionSearchRedirect() {
 }
 
 function EditEntityRedirect() {
-  const { name, entryName } = useParams();
-  return <Navigate to={`/collections/${name}/entries/${entryName}`} />;
+  const params = useParams();
+  return <Navigate to={`/collections/${params.name}/entries/${params['*']}`} />;
 }
 
 const App = ({
@@ -199,7 +199,7 @@ const App = ({
             element={<EditorRoute collections={collections} newRecord />}
           />
           <Route
-            path="/collections/:name/entries/:slug"
+            path="/collections/:name/entries/*"
             element={<EditorRoute collections={collections} />}
           />
           <Route
@@ -209,14 +209,14 @@ const App = ({
             }
           />
           <Route
-            path="/collections/:name/filter/:filterTerm"
+            path="/collections/:name/filter/*"
             element={<CollectionRoute collections={collections} />}
           />
           <Route
             path="/search/:searchTerm"
             element={<CollectionRoute collections={collections} isSearchResults />}
           />
-          <Route path="/edit/:name/:entryName" element={<EditEntityRedirect />} />
+          <Route path="/edit/:name/*" element={<EditEntityRedirect />} />
           <Route path="/page/:id" element={<Page />} />
           <Route element={<NotFoundPage />} />
         </Routes>

--- a/packages/core/src/components/Collection/CollectionRoute.tsx
+++ b/packages/core/src/components/Collection/CollectionRoute.tsx
@@ -18,7 +18,9 @@ const CollectionRoute = ({
   isSingleSearchResult,
   collections,
 }: CollectionRouteProps) => {
-  const { name, searchTerm, filterTerm } = useParams();
+  const params = useParams();
+  const { name, searchTerm } = params;
+  const filterTerm = params['*'];
   const collection = useMemo(() => {
     if (!name) {
       return false;

--- a/packages/core/src/components/Editor/EditorRoute.tsx
+++ b/packages/core/src/components/Editor/EditorRoute.tsx
@@ -12,7 +12,9 @@ interface EditorRouteProps {
 }
 
 const EditorRoute = ({ newRecord = false, collections }: EditorRouteProps) => {
-  const { name, slug } = useParams();
+  const params = useParams();
+  const name = params.name;
+  const slug = params['*'];
   const shouldRedirect = useMemo(() => {
     if (!name) {
       return false;


### PR DESCRIPTION
Towards #63
Complements fix for #393

## Summary

The nested folders feature is currently broken.

This PR addresses routing changes, to allow for entry paths including `/` being passed to several components.
