### PR TITLE
fix: sidebar height

### DIFF
--- a/packages/core/src/components/navbar/Sidebar.tsx
+++ b/packages/core/src/components/navbar/Sidebar.tsx
@@ -98,7 +98,7 @@ const Sidebar: FC<TranslateProps> = ({ t }) => {
     <aside
       className={classNames(
         'w-sidebar-expanded',
-        'h-full sm:fixed sm:z-20 sm:shadow-sidebar lg:block lg:z-auto lg:shadow-none',
+        'h-main sm:fixed sm:z-20 sm:shadow-sidebar lg:block lg:z-auto lg:shadow-none',
       )}
       aria-label="Sidebar"
     >


### PR DESCRIPTION
Small fix for sidebar height. When having too many entries/collections in the sidebar, scrolling is being activated. When using h-full class, the last entry is often hidden without having the possibility to scroll down. When using h-main as in the collection page, everything works as expected.