### PR TITLE
feat: extend tailwind config to use Inter sans

### DIFF
--- a/tailwind.base.config.js
+++ b/tailwind.base.config.js
@@ -34,6 +34,9 @@ module.exports = {
         editor: '450px auto',
         'media-preview': '126px auto',
       },
+      fontFamily: {
+        sans: ['Inter var', 'Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+      },
     },
   },
 };


### PR DESCRIPTION
The stylesheet `packages/core/src/styles/inter.css` is imported but Inter font family is not configured anywhere.
It's not a bug, but since `inter.css` exists I figured the intention is to use it.
 