### PR TITLE
fix: draft folders

### DIFF
--- a/packages/core/src/lib/hooks/useMediaFiles.ts
+++ b/packages/core/src/lib/hooks/useMediaFiles.ts
@@ -1,5 +1,6 @@
 import { basename, dirname } from 'path';
 import { useEffect, useMemo, useState } from 'react';
+import trim from 'lodash/trim';
 
 import { currentBackend } from '@staticcms/core/backend';
 import { selectCollection } from '@staticcms/core/reducers/selectors/collections';
@@ -44,8 +45,15 @@ export default function useMediaFiles(field?: MediaField, currentFolder?: string
         setCurrentFolderMediaFiles([]);
         return;
       }
+      const { media_folder, public_folder } = config ?? {};
       const backend = currentBackend(config);
-      const files = await backend.getMedia(currentFolder, folderSupport);
+      const files = await backend.getMedia(
+        currentFolder,
+        folderSupport,
+        public_folder
+          ? trim(currentFolder, '/').replace(trim(media_folder, '/'), public_folder)
+          : currentFolder,
+      );
 
       if (alive) {
         setCurrentFolderMediaFiles(files);

--- a/packages/core/src/lib/hooks/useMediaFiles.ts
+++ b/packages/core/src/lib/hooks/useMediaFiles.ts
@@ -1,4 +1,3 @@
-import trim from 'lodash/trim';
 import { basename, dirname } from 'path';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -41,14 +40,12 @@ export default function useMediaFiles(field?: MediaField, currentFolder?: string
     let alive = true;
 
     const getMediaFiles = async () => {
+      if (entry.mediaFiles.find(f => dirname(f.path) == currentFolder)?.draft) {
+        setCurrentFolderMediaFiles([]);
+        return;
+      }
       const backend = currentBackend(config);
-      const files = await backend.getMedia(
-        currentFolder,
-        folderSupport,
-        config.public_folder
-          ? trim(currentFolder, '/').replace(trim(config.media_folder!), config.public_folder)
-          : currentFolder,
-      );
+      const files = await backend.getMedia(currentFolder, folderSupport);
 
       if (alive) {
         setCurrentFolderMediaFiles(files);
@@ -60,7 +57,7 @@ export default function useMediaFiles(field?: MediaField, currentFolder?: string
     return () => {
       alive = false;
     };
-  }, [currentFolder, config, entry, field, collection, folderSupport]);
+  }, [currentFolder, config, entry, folderSupport]);
 
   const files = useMemo(() => {
     if (entry) {


### PR DESCRIPTION
When using media library folders in a draft entry and creating a new folder, the media library tries to fetch it's content from backend, and when it fails it falls back to the content of the previous folder. To prevent that from happening every time, this PR includes a check if the folder is a draft and simply uses a blank file list in that case.

Also some small cleanups in the code for useMediaFiles hook.