### PR TITLE
docs: Fix typos in the Decap CMS Migration Guide

### DIFF
--- a/packages/docs/content/docs/decap-migration-guide.mdx
+++ b/packages/docs/content/docs/decap-migration-guide.mdx
@@ -59,7 +59,7 @@ React `18.2.0` is now the minimum supported React version. If you are using Stat
 
 ### Static CMS Styles
 
-Static CMS bundles it styles separately from the main javascript file, so you will need to import them separately.
+Static CMS bundles its styles separately from the main javascript file, so you will need to import them separately.
 
 **CDN**:
 
@@ -75,7 +75,7 @@ import '@staticcms/core/dist/main.css';
 
 ### Backends
 
-The Azure backend has been remove. All other backends are still supported.
+The Azure backend has been removed. All other backends are still supported.
 
 However, the Gitlab, Client-Side Implicit Grant has been removed as a method of authentication.
 


### PR DESCRIPTION
In the section "Static CMS Styles":
Incorrect: Static CMS bundles it styles separately... Corrected: Static CMS bundles its styles separately...

In the section "Backends":
Incorrect: The Azure backend has been remove...
Corrected: The Azure backend has been removed...