### PR TITLE
fix: media library placeholder image width (Firefox / Safari)

### DIFF
--- a/packages/core/src/components/common/image/Image.tsx
+++ b/packages/core/src/components/common/image/Image.tsx
@@ -40,6 +40,7 @@ const Image = <EF extends BaseField = UnknownField>({
           p-10
           rounded-md
           border
+          max-w-full
           border-gray-200/75
           dark:border-slate-600/75
         "


### PR DESCRIPTION
Fixes #809 