### PR TITLE
fix: resizing the editor doesn't work correctly in Firefox due to pointer events being captured in the preview pane

### DIFF
--- a/packages/core/src/components/entry-editor/EditorInterface.tsx
+++ b/packages/core/src/components/entry-editor/EditorInterface.tsx
@@ -417,6 +417,7 @@ const EditorInterface: FC<EditorInterfaceProps> = ({
             classes.root,
             editorSize === EDITOR_SIZE_COMPACT && classes.compact,
           )}
+          disablePointerEventsDuringResize={true}
         >
           <Panel defaultSize={COMPACT_EDITOR_DEFAULT_WIDTH} minSize={COMPACT_EDITOR_DEFAULT_WIDTH}>
             <ScrollSyncPane>{editor}</ScrollSyncPane>


### PR DESCRIPTION
Fix https://github.com/StaticJsCMS/static-cms/issues/955
bug: resizing the editor doesn't work correctly in Firefox due to pointer events being captured in the preview pane