### PR TITLE
feat: basic support for mdx file extension

### DIFF
--- a/packages/app/.editorconfig
+++ b/packages/app/.editorconfig
@@ -17,3 +17,6 @@ quote_type = single
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.mdx]
+trim_trailing_whitespace = false

--- a/packages/core/.editorconfig
+++ b/packages/core/.editorconfig
@@ -17,3 +17,6 @@ quote_type = single
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.mdx]
+trim_trailing_whitespace = false

--- a/packages/core/dev-test/backends/proxy/_data/navigation.mdx
+++ b/packages/core/dev-test/backends/proxy/_data/navigation.mdx
@@ -1,0 +1,26 @@
+---
+main_menu:
+  - label: News
+    href: /news
+  - label: Features
+    href: '#features'
+  - label: About
+    href: '#about'
+  - label: Contact
+    href: '#contact'
+footer_menus:
+  - label: Company
+    links:
+      - label: Home
+        href: /
+      - label: 'Privacy Policy '
+        href: '#'
+      - label: About us
+        href: '#'
+  - label: Documentation
+    links:
+      - label: Docs
+        href: '#'
+      - label: Blog
+        href: '#'
+---

--- a/packages/core/dev-test/backends/proxy/config.yml
+++ b/packages/core/dev-test/backends/proxy/config.yml
@@ -176,6 +176,45 @@ collections:
               - label: Description
                 name: description
                 widget: text
+
+      - name: navigation
+        label: Navigation
+        file: packages/core/dev-test/backends/proxy/_data/navigation.mdx
+        extension: mdx
+        format: yaml-frontmatter
+        fields:
+          - name: main_menu
+            label: Main Menu
+            widget: list
+            collapsed: true
+            fields:
+              - name: label
+                label: Label
+                widget: string
+              - name: href
+                label: Href
+                widget: string
+          - name: footer_menus
+            label: Footer Menus
+            widget: list
+            collapsed: true
+            reuired: false
+            fields:
+              - name: label
+                label: Label
+                widget: string
+              - name: links
+                label: Links
+                widget: list
+                collapsed: true
+                fields:
+                  - name: label
+                    label: Label
+                    widget: string
+                  - name: href
+                    label: Href
+                    widget: string
+
   - name: kitchenSink
     label: Kitchen Sink
     folder: packages/core/dev-test/backends/proxy/_sink

--- a/packages/core/src/formats/formats.ts
+++ b/packages/core/src/formats/formats.ts
@@ -26,6 +26,7 @@ export const extensionFormatters: Record<string, FileFormatter> = {
   toml: TomlFormatter,
   json: JsonFormatter,
   md: FrontmatterInfer,
+  mdx: FrontmatterInfer,
   markdown: FrontmatterInfer,
   html: FrontmatterInfer,
 };

--- a/packages/docs/.editorconfig
+++ b/packages/docs/.editorconfig
@@ -17,3 +17,6 @@ quote_type = single
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.mdx]
+trim_trailing_whitespace = false

--- a/packages/docs/content/docs/collection-overview.mdx
+++ b/packages/docs/content/docs/collection-overview.mdx
@@ -57,7 +57,7 @@ collections: [
 
 These settings determine how collection files are parsed and saved. Both are optional—Static CMS will attempt to infer your settings based on existing items in the collection. If your collection is empty, or you'd like more control, you can set these fields explicitly.
 
-`extension` determines the file extension searched for when finding existing entries in a folder collection and it determines the file extension used to save new collection items. It accepts the following values: `yml`, `yaml`, `json`, `md`, `markdown`, `html`.
+`extension` determines the file extension searched for when finding existing entries in a folder collection and it determines the file extension used to save new collection items. It accepts the following values: `yml`, `yaml`, `json`, `md`, `markdown`, `mdx`, `html`.
 
 You may also specify a custom `extension` not included in the list above, as long as the collection files can be parsed and saved in one of the supported formats below.
 


### PR DESCRIPTION
This does not provide editor support for MDX components, but simply allows the mdx file extension to be used. Static CMS will read the file just like it would a Markdown file.

Related to #81 
Resolves #963 