### PR TITLE
feat: allow events to be registered without collection specified

### DIFF
--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -1121,33 +1121,46 @@ export interface EventData {
 
 export interface PrePublishEventListener {
   name: 'prePublish';
-  collection: string;
-  file?: string;
-  handler: (event: { data: EventData; collection: string }) => void | Promise<void>;
-}
-
-export interface PostPublishEventListener {
-  name: 'postPublish';
-  collection: string;
-  file?: string;
-  handler: (event: { data: EventData; collection: string }) => void | Promise<void>;
-}
-
-export interface PreSaveEventListener {
-  name: 'preSave';
-  collection: string;
+  collection?: string;
   file?: string;
   handler: (event: {
     data: EventData;
     collection: string;
+    file: string | undefined;
+  }) => void | Promise<void>;
+}
+
+export interface PostPublishEventListener {
+  name: 'postPublish';
+  collection?: string;
+  file?: string;
+  handler: (event: {
+    data: EventData;
+    collection: string;
+    file: string | undefined;
+  }) => void | Promise<void>;
+}
+
+export interface PreSaveEventListener {
+  name: 'preSave';
+  collection?: string;
+  file?: string;
+  handler: (event: {
+    data: EventData;
+    collection: string;
+    file: string | undefined;
   }) => EntryData | undefined | null | void | Promise<EntryData | undefined | null | void>;
 }
 
 export interface PostSaveEventListener {
   name: 'postSave';
-  collection: string;
+  collection?: string;
   file?: string;
-  handler: (event: { data: EventData; collection: string }) => void | Promise<void>;
+  handler: (event: {
+    data: EventData;
+    collection: string;
+    file: string | undefined;
+  }) => void | Promise<void>;
 }
 
 export interface MountedEventListener {
@@ -1157,9 +1170,7 @@ export interface MountedEventListener {
 
 export interface LoginEventListener {
   name: 'login';
-  handler: (event: {
-    author: AuthorData;
-  }) => EntryData | undefined | null | void | Promise<EntryData | undefined | null | void>;
+  handler: (event: { author: AuthorData }) => void | Promise<void>;
 }
 
 export interface LogoutEventListener {
@@ -1169,17 +1180,20 @@ export interface LogoutEventListener {
 
 export interface ChangeEventListener {
   name: 'change';
-  collection: string;
+  collection?: string;
   file?: string;
-  field: string;
+  field?: string;
   handler: (event: {
     data: EntryData;
     collection: string;
+    file: string | undefined;
     field: string;
   }) => EntryData | undefined | null | void | Promise<EntryData | undefined | null | void>;
 }
 
 export type EventListener =
+  | PrePublishEventListener
+  | PostPublishEventListener
   | PreSaveEventListener
   | PostSaveEventListener
   | ChangeEventListener

--- a/packages/core/src/lib/__tests__/registry.spec.ts
+++ b/packages/core/src/lib/__tests__/registry.spec.ts
@@ -1,0 +1,1399 @@
+import { createMockEntry } from '@staticcms/test/data/entry.mock';
+import { invokeEvent, registerEventListener, removeEventListener } from '../registry';
+import set from '../util/set.util';
+
+import type { EventListener } from '@staticcms/core/interface';
+
+describe('registry', () => {
+  let listener: EventListener | undefined;
+
+  afterEach(() => {
+    if (listener) {
+      removeEventListener(listener);
+      listener = undefined;
+    }
+  });
+
+  describe('events', () => {
+    it('should invoke registered login event', done => {
+      listener = {
+        name: 'login',
+        handler: ({ author }) => {
+          expect(author).toEqual({
+            login: 'username',
+            name: 'User Name',
+          });
+          done();
+        },
+      };
+
+      registerEventListener(listener);
+
+      invokeEvent({
+        name: 'login',
+        data: {
+          login: 'username',
+          name: 'User Name',
+        },
+      });
+    });
+
+    it('should invoke registered logout event', done => {
+      listener = {
+        name: 'logout',
+        handler: () => {
+          done();
+        },
+      };
+
+      registerEventListener(listener);
+
+      invokeEvent({
+        name: 'logout',
+      });
+    });
+
+    it('should invoke registered mounted event', done => {
+      listener = {
+        name: 'mounted',
+        handler: () => {
+          done();
+        },
+      };
+
+      registerEventListener(listener);
+
+      invokeEvent({
+        name: 'mounted',
+      });
+    });
+
+    describe('change event', () => {
+      describe('folder collection', () => {
+        it('should invoke event listener for all changes', async () => {
+          listener = {
+            name: 'change',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: undefined,
+                field: 'path.to.field',
+                data: {
+                  path: {
+                    to: {
+                      field: 'fieldValue',
+                    },
+                  },
+                },
+              });
+
+              return set(data.data, data.field, 'NEW FIELD VALUE');
+            },
+          };
+
+          registerEventListener(listener);
+
+          expect(
+            await invokeEvent({
+              name: 'change',
+              collection: 'collectionName',
+              field: 'path.to.field',
+              fieldName: 'fieldName',
+              data: {
+                path: {
+                  to: {
+                    field: 'fieldValue',
+                  },
+                },
+              },
+            }),
+          ).toEqual({
+            path: {
+              to: {
+                field: 'NEW FIELD VALUE',
+              },
+            },
+          });
+        });
+
+        it('should invoke event listener for whole collection changes', async () => {
+          listener = {
+            name: 'change',
+            collection: 'collectionName',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: undefined,
+                field: 'path.to.field',
+                data: {
+                  path: {
+                    to: {
+                      field: 'fieldValue',
+                    },
+                  },
+                },
+              });
+
+              return set(data.data, data.field, 'NEW FIELD VALUE');
+            },
+          };
+
+          registerEventListener(listener);
+
+          expect(
+            await invokeEvent({
+              name: 'change',
+              collection: 'collectionName',
+              field: 'path.to.field',
+              fieldName: 'fieldName',
+              data: {
+                path: {
+                  to: {
+                    field: 'fieldValue',
+                  },
+                },
+              },
+            }),
+          ).toEqual({
+            path: {
+              to: {
+                field: 'NEW FIELD VALUE',
+              },
+            },
+          });
+        });
+
+        it('should invoke event listener for specific field changes', async () => {
+          listener = {
+            name: 'change',
+            collection: 'collectionName',
+            field: 'path.to.field',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: undefined,
+                field: 'path.to.field',
+                data: {
+                  path: {
+                    to: {
+                      field: 'fieldValue',
+                    },
+                  },
+                },
+              });
+
+              return set(data.data, data.field, 'NEW FIELD VALUE');
+            },
+          };
+
+          registerEventListener(listener);
+
+          expect(
+            await invokeEvent({
+              name: 'change',
+              collection: 'collectionName',
+              field: 'path.to.field',
+              fieldName: 'fieldName',
+              data: {
+                path: {
+                  to: {
+                    field: 'fieldValue',
+                  },
+                },
+              },
+            }),
+          ).toEqual({
+            path: {
+              to: {
+                field: 'NEW FIELD VALUE',
+              },
+            },
+          });
+        });
+      });
+
+      describe('file collection', () => {
+        it('should invoke event listener for all changes', async () => {
+          listener = {
+            name: 'change',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: 'fileName',
+                field: 'path.to.field',
+                data: {
+                  path: {
+                    to: {
+                      field: 'fieldValue',
+                    },
+                  },
+                },
+              });
+
+              return set(data.data, data.field, 'NEW FIELD VALUE');
+            },
+          };
+
+          registerEventListener(listener);
+
+          expect(
+            await invokeEvent({
+              name: 'change',
+              collection: 'collectionName',
+              file: 'fileName',
+              field: 'path.to.field',
+              fieldName: 'fieldName',
+              data: {
+                path: {
+                  to: {
+                    field: 'fieldValue',
+                  },
+                },
+              },
+            }),
+          ).toEqual({
+            path: {
+              to: {
+                field: 'NEW FIELD VALUE',
+              },
+            },
+          });
+        });
+
+        it('should invoke event listener for whole collection changes', async () => {
+          listener = {
+            name: 'change',
+            collection: 'collectionName',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: 'fileName',
+                field: 'path.to.field',
+                data: {
+                  path: {
+                    to: {
+                      field: 'fieldValue',
+                    },
+                  },
+                },
+              });
+
+              return set(data.data, data.field, 'NEW FIELD VALUE');
+            },
+          };
+
+          registerEventListener(listener);
+
+          expect(
+            await invokeEvent({
+              name: 'change',
+              collection: 'collectionName',
+              file: 'fileName',
+              field: 'path.to.field',
+              fieldName: 'fieldName',
+              data: {
+                path: {
+                  to: {
+                    field: 'fieldValue',
+                  },
+                },
+              },
+            }),
+          ).toEqual({
+            path: {
+              to: {
+                field: 'NEW FIELD VALUE',
+              },
+            },
+          });
+        });
+
+        it('should invoke event listener for whole file changes', async () => {
+          listener = {
+            name: 'change',
+            collection: 'collectionName',
+            file: 'fileName',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: 'fileName',
+                field: 'path.to.field',
+                data: {
+                  path: {
+                    to: {
+                      field: 'fieldValue',
+                    },
+                  },
+                },
+              });
+
+              return set(data.data, data.field, 'NEW FIELD VALUE');
+            },
+          };
+
+          registerEventListener(listener);
+
+          expect(
+            await invokeEvent({
+              name: 'change',
+              collection: 'collectionName',
+              file: 'fileName',
+              field: 'path.to.field',
+              fieldName: 'fieldName',
+              data: {
+                path: {
+                  to: {
+                    field: 'fieldValue',
+                  },
+                },
+              },
+            }),
+          ).toEqual({
+            path: {
+              to: {
+                field: 'NEW FIELD VALUE',
+              },
+            },
+          });
+        });
+
+        it('should invoke event listener for specific field changes', async () => {
+          listener = {
+            name: 'change',
+            collection: 'collectionName',
+            field: 'path.to.field',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: 'fileName',
+                field: 'path.to.field',
+                data: {
+                  path: {
+                    to: {
+                      field: 'fieldValue',
+                    },
+                  },
+                },
+              });
+
+              return set(data.data, data.field, 'NEW FIELD VALUE');
+            },
+          };
+
+          registerEventListener(listener);
+
+          expect(
+            await invokeEvent({
+              name: 'change',
+              collection: 'collectionName',
+              file: 'fileName',
+              field: 'path.to.field',
+              fieldName: 'fieldName',
+              data: {
+                path: {
+                  to: {
+                    field: 'fieldValue',
+                  },
+                },
+              },
+            }),
+          ).toEqual({
+            path: {
+              to: {
+                field: 'NEW FIELD VALUE',
+              },
+            },
+          });
+        });
+      });
+    });
+
+    describe('preSave event', () => {
+      describe('folder collection', () => {
+        it('should invoke event listener for all changes', async () => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'preSave',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: undefined,
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              return set(data.data.entry.data, 'path.to.field', 'NEW FIELD VALUE');
+            },
+          };
+
+          registerEventListener(listener);
+
+          expect(
+            await invokeEvent({
+              name: 'preSave',
+              collection: 'collectionName',
+              data: {
+                author: {
+                  login: 'username',
+                  name: 'User Name',
+                },
+                entry,
+              },
+            }),
+          ).toEqual({
+            path: {
+              to: {
+                field: 'NEW FIELD VALUE',
+              },
+            },
+          });
+        });
+
+        it('should invoke event listener for whole collection changes', async () => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'preSave',
+            collection: 'collectionName',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              return set(data.data.entry.data, 'path.to.field', 'NEW FIELD VALUE');
+            },
+          };
+
+          registerEventListener(listener);
+
+          expect(
+            await invokeEvent({
+              name: 'preSave',
+              collection: 'collectionName',
+              data: {
+                author: {
+                  login: 'username',
+                  name: 'User Name',
+                },
+                entry,
+              },
+            }),
+          ).toEqual({
+            path: {
+              to: {
+                field: 'NEW FIELD VALUE',
+              },
+            },
+          });
+        });
+      });
+
+      describe('file collection', () => {
+        it('should invoke event listener for all changes', async () => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'preSave',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: 'fileName',
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              return set(data.data.entry.data, 'path.to.field', 'NEW FIELD VALUE');
+            },
+          };
+
+          registerEventListener(listener);
+
+          expect(
+            await invokeEvent({
+              name: 'preSave',
+              collection: 'collectionName',
+              file: 'fileName',
+              data: {
+                author: {
+                  login: 'username',
+                  name: 'User Name',
+                },
+                entry,
+              },
+            }),
+          ).toEqual({
+            path: {
+              to: {
+                field: 'NEW FIELD VALUE',
+              },
+            },
+          });
+        });
+
+        it('should invoke event listener for whole collection changes', async () => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'preSave',
+            collection: 'collectionName',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: 'fileName',
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              return set(data.data.entry.data, 'path.to.field', 'NEW FIELD VALUE');
+            },
+          };
+
+          registerEventListener(listener);
+
+          expect(
+            await invokeEvent({
+              name: 'preSave',
+              collection: 'collectionName',
+              file: 'fileName',
+              data: {
+                author: {
+                  login: 'username',
+                  name: 'User Name',
+                },
+                entry,
+              },
+            }),
+          ).toEqual({
+            path: {
+              to: {
+                field: 'NEW FIELD VALUE',
+              },
+            },
+          });
+        });
+
+        it('should invoke event listener for whole file changes', async () => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'preSave',
+            collection: 'collectionName',
+            file: 'fileName',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: 'fileName',
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              return set(data.data.entry.data, 'path.to.field', 'NEW FIELD VALUE');
+            },
+          };
+
+          registerEventListener(listener);
+
+          expect(
+            await invokeEvent({
+              name: 'preSave',
+              collection: 'collectionName',
+              file: 'fileName',
+              data: {
+                author: {
+                  login: 'username',
+                  name: 'User Name',
+                },
+                entry,
+              },
+            }),
+          ).toEqual({
+            path: {
+              to: {
+                field: 'NEW FIELD VALUE',
+              },
+            },
+          });
+        });
+      });
+    });
+
+    describe('postSave event', () => {
+      describe('folder collection', () => {
+        it('should invoke event listener for all changes', done => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'postSave',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: undefined,
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              done();
+            },
+          };
+
+          registerEventListener(listener);
+
+          invokeEvent({
+            name: 'postSave',
+            collection: 'collectionName',
+            data: {
+              author: {
+                login: 'username',
+                name: 'User Name',
+              },
+              entry,
+            },
+          });
+        });
+
+        it('should invoke event listener for whole collection changes', done => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'postSave',
+            collection: 'collectionName',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              done();
+            },
+          };
+
+          registerEventListener(listener);
+
+          invokeEvent({
+            name: 'postSave',
+            collection: 'collectionName',
+            data: {
+              author: {
+                login: 'username',
+                name: 'User Name',
+              },
+              entry,
+            },
+          });
+        });
+      });
+
+      describe('file collection', () => {
+        it('should invoke event listener for all changes', done => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'postSave',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: 'fileName',
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              done();
+            },
+          };
+
+          registerEventListener(listener);
+
+          invokeEvent({
+            name: 'postSave',
+            collection: 'collectionName',
+            file: 'fileName',
+            data: {
+              author: {
+                login: 'username',
+                name: 'User Name',
+              },
+              entry,
+            },
+          });
+        });
+
+        it('should invoke event listener for whole collection changes', done => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'postSave',
+            collection: 'collectionName',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: 'fileName',
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              done();
+            },
+          };
+
+          registerEventListener(listener);
+
+          invokeEvent({
+            name: 'postSave',
+            collection: 'collectionName',
+            file: 'fileName',
+            data: {
+              author: {
+                login: 'username',
+                name: 'User Name',
+              },
+              entry,
+            },
+          });
+        });
+
+        it('should invoke event listener for whole file changes', done => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'postSave',
+            collection: 'collectionName',
+            file: 'fileName',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: 'fileName',
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              done();
+            },
+          };
+
+          registerEventListener(listener);
+
+          invokeEvent({
+            name: 'postSave',
+            collection: 'collectionName',
+            file: 'fileName',
+            data: {
+              author: {
+                login: 'username',
+                name: 'User Name',
+              },
+              entry,
+            },
+          });
+        });
+      });
+    });
+
+    describe('prePublish event', () => {
+      describe('folder collection', () => {
+        it('should invoke event listener for all changes', done => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'prePublish',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: undefined,
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              done();
+            },
+          };
+
+          registerEventListener(listener);
+
+          invokeEvent({
+            name: 'prePublish',
+            collection: 'collectionName',
+            data: {
+              author: {
+                login: 'username',
+                name: 'User Name',
+              },
+              entry,
+            },
+          });
+        });
+
+        it('should invoke event listener for whole collection changes', done => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'prePublish',
+            collection: 'collectionName',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              done();
+            },
+          };
+
+          registerEventListener(listener);
+
+          invokeEvent({
+            name: 'prePublish',
+            collection: 'collectionName',
+            data: {
+              author: {
+                login: 'username',
+                name: 'User Name',
+              },
+              entry,
+            },
+          });
+        });
+      });
+
+      describe('file collection', () => {
+        it('should invoke event listener for all changes', done => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'prePublish',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: 'fileName',
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              done();
+            },
+          };
+
+          registerEventListener(listener);
+
+          invokeEvent({
+            name: 'prePublish',
+            collection: 'collectionName',
+            file: 'fileName',
+            data: {
+              author: {
+                login: 'username',
+                name: 'User Name',
+              },
+              entry,
+            },
+          });
+        });
+
+        it('should invoke event listener for whole collection changes', done => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'prePublish',
+            collection: 'collectionName',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: 'fileName',
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              done();
+            },
+          };
+
+          registerEventListener(listener);
+
+          invokeEvent({
+            name: 'prePublish',
+            collection: 'collectionName',
+            file: 'fileName',
+            data: {
+              author: {
+                login: 'username',
+                name: 'User Name',
+              },
+              entry,
+            },
+          });
+        });
+
+        it('should invoke event listener for whole file changes', done => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'prePublish',
+            collection: 'collectionName',
+            file: 'fileName',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: 'fileName',
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              done();
+            },
+          };
+
+          registerEventListener(listener);
+
+          invokeEvent({
+            name: 'prePublish',
+            collection: 'collectionName',
+            file: 'fileName',
+            data: {
+              author: {
+                login: 'username',
+                name: 'User Name',
+              },
+              entry,
+            },
+          });
+        });
+      });
+    });
+
+    describe('postPublish event', () => {
+      describe('folder collection', () => {
+        it('should invoke event listener for all changes', done => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'postPublish',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: undefined,
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              done();
+            },
+          };
+
+          registerEventListener(listener);
+
+          invokeEvent({
+            name: 'postPublish',
+            collection: 'collectionName',
+            data: {
+              author: {
+                login: 'username',
+                name: 'User Name',
+              },
+              entry,
+            },
+          });
+        });
+
+        it('should invoke event listener for whole collection changes', done => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'postPublish',
+            collection: 'collectionName',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              done();
+            },
+          };
+
+          registerEventListener(listener);
+
+          invokeEvent({
+            name: 'postPublish',
+            collection: 'collectionName',
+            data: {
+              author: {
+                login: 'username',
+                name: 'User Name',
+              },
+              entry,
+            },
+          });
+        });
+      });
+
+      describe('file collection', () => {
+        it('should invoke event listener for all changes', done => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'postPublish',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: 'fileName',
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              done();
+            },
+          };
+
+          registerEventListener(listener);
+
+          invokeEvent({
+            name: 'postPublish',
+            collection: 'collectionName',
+            file: 'fileName',
+            data: {
+              author: {
+                login: 'username',
+                name: 'User Name',
+              },
+              entry,
+            },
+          });
+        });
+
+        it('should invoke event listener for whole collection changes', done => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'postPublish',
+            collection: 'collectionName',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: 'fileName',
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              done();
+            },
+          };
+
+          registerEventListener(listener);
+
+          invokeEvent({
+            name: 'postPublish',
+            collection: 'collectionName',
+            file: 'fileName',
+            data: {
+              author: {
+                login: 'username',
+                name: 'User Name',
+              },
+              entry,
+            },
+          });
+        });
+
+        it('should invoke event listener for whole file changes', done => {
+          const entry = createMockEntry({
+            data: {
+              path: {
+                to: {
+                  field: 'fieldValue',
+                },
+              },
+            },
+          });
+
+          listener = {
+            name: 'postPublish',
+            collection: 'collectionName',
+            file: 'fileName',
+            handler: data => {
+              expect(data).toEqual({
+                collection: 'collectionName',
+                file: 'fileName',
+                data: {
+                  author: {
+                    login: 'username',
+                    name: 'User Name',
+                  },
+                  entry,
+                },
+              });
+
+              done();
+            },
+          };
+
+          registerEventListener(listener);
+
+          invokeEvent({
+            name: 'postPublish',
+            collection: 'collectionName',
+            file: 'fileName',
+            data: {
+              author: {
+                login: 'username',
+                name: 'User Name',
+              },
+              entry,
+            },
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/core/src/lib/hooks/useEntryCallback.ts
+++ b/packages/core/src/lib/hooks/useEntryCallback.ts
@@ -32,8 +32,8 @@ async function handleChange(
     newEntry = await invokeEvent({
       name: 'change',
       collection,
-      field: field.name,
-      fieldPath,
+      fieldName: field.name,
+      field: fieldPath,
       data: newEntry,
     });
 

--- a/packages/docs/content/docs/cms-events.mdx
+++ b/packages/docs/content/docs/cms-events.mdx
@@ -8,16 +8,16 @@ You can execute a function when a specific event occurs within Static CMSD.
 
 Supported events are:
 
-| Name        | Description                                                                                                             |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------- |
-| mounted     | Event fires once Static CMS is fully loaded                                                                             |
-| login       | Event fires when a user logs into Static CMS                                                                            |
-| logout      | Event fires when a user logs out of Static CMS                                                                          |
-| change      | Event fires when a user changes the value of a field in the editor                                                      |
-| preSave     | Event fires before the changes have been saved to your git backend                                                      |
-| postSave    | Event fires after the changes have been saved to your git backend                                                       |
-| prePublish  | _**Editorial Workflow ONLY**_. Event fires before the entry is "published", before the PR is merged into default branch |
-| postPublish | _**Editorial Workflow ONLY**_. Event fires after the entry is "published", after the PR is merged into default branch   |
+| Name                               | Description                                                                                                             |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| [mounted](#mounted-event)          | Event fires once Static CMS is fully loaded                                                                             |
+| [login](#login-event)              | Event fires when a user logs into Static CMS                                                                            |
+| [logout](#logout-event)            | Event fires when a user logs out of Static CMS                                                                          |
+| [change](#change-event)            | Event fires when a user changes the value of a field in the editor                                                      |
+| [preSave](#pre-save-event)         | Event fires before the changes have been saved to your git backend                                                      |
+| [postSave](#post-save-event)       | Event fires after the changes have been saved to your git backend                                                       |
+| [prePublish](#pre-publish-event)   | _**Editorial Workflow ONLY**_. Event fires before the entry is "published", before the PR is merged into default branch |
+| [postPublish](#post-publish-event) | _**Editorial Workflow ONLY**_. Event fires after the entry is "published", after the PR is merged into default branch   |
 
 ## Mounted Event
 
@@ -60,12 +60,52 @@ CMS.registerEventListener({
 
 ## Change Event
 
-The `change` event handler fires when a user changes the value of a field in the editor. Event listeners for `change` must provide a field name, and can be used to modify the entry data like so:
+The `change` event handler fires when a user changes the value of a field in the editor. Event listeners for `change` can optionally provide collection, file and field names. They can also be used to modify the entry data.
 
 ```javascript
+// Listen for ALL change events
+CMS.registerEventListener({
+  name: 'change',
+  handler: ({ data, collection, field }) => {
+    // Your handler code
+  },
+});
+
+// Listen for all change events in a specific collection
 CMS.registerEventListener({
   name: 'change',
   collection: 'posts',
+  handler: ({ data, collection, field }) => {
+    // Your handler code
+  },
+});
+
+// Listen for all change events in a specific file in a collection
+CMS.registerEventListener({
+  name: 'change',
+  collection: 'settings',
+  file: 'global',
+  handler: ({ data, collection, field }) => {
+    // Your handler code
+  },
+});
+
+// Listen for all change events in a specific field in a collection
+CMS.registerEventListener({
+  name: 'change',
+  collection: 'posts',
+  // file: 'global', // You can specify a file if in a file collection
+  field: 'path.to.my.field',
+  handler: ({ data, collection, field }) => {
+    // Your handler code
+  },
+});
+
+// Alter the entry data when a specific field changes
+CMS.registerEventListener({
+  name: 'change',
+  collection: 'posts',
+  // file: 'global', // You can specify a file if in a file collection
   field: 'path.to.my.field',
   handler: ({ data, collection, field }) => {
     const currentValue = data.path.to.my.field;
@@ -89,16 +129,56 @@ CMS.registerEventListener({
 
 ## Pre Save Event
 
-The `preSave` event handler fires before the changes have been saved to your git backend, and can be used to modify the entry data like so:
+The `preSave` event handler fires before the changes have been saved to your git backend, and can be used to modify the entry data.
 
 ```javascript
+// Listen for ALL preSave events
+CMS.registerEventListener({
+  name: 'preSave',
+  handler: ({ data, collection, field }) => {
+    // Your handler code
+  },
+});
+
+// Listen for all preSave events in a specific collection
 CMS.registerEventListener({
   name: 'preSave',
   collection: 'posts',
-  handler: ({ data: { entry } }) => {
+  handler: ({ data, collection, field }) => {
+    // Your handler code
+  },
+});
+
+// Listen for all preSave events in a specific file in a collection
+CMS.registerEventListener({
+  name: 'preSave',
+  collection: 'settings',
+  file: 'global',
+  handler: ({ data, collection, field }) => {
+    // Your handler code
+  },
+});
+
+// Alter the entry data
+CMS.registerEventListener({
+  name: 'preSave',
+  collection: 'posts',
+  // file: 'global', // You can specify a file if in a file collection
+  handler: ({ data, collection, field }) => {
+    const currentValue = data.path.to.my.field;
+
     return {
-      ...entry.data,
-      title: 'new title',
+      ...data,
+      path: {
+        ...data.path,
+        to: {
+          ...data.path.to,
+          my: {
+            ...data.path.to.my,
+            field: `new${currentValue}`,
+          },
+        },
+      },
     };
   },
 });
@@ -109,11 +189,100 @@ CMS.registerEventListener({
 The `postSave` event handler fires after the changes have been saved to your git backend.
 
 ```javascript
+// Listen for ALL postSave events
+CMS.registerEventListener({
+  name: 'postSave',
+  handler: ({ data, collection, field }) => {
+    // Your handler code
+  },
+});
+
+// Listen for all postSave events in a specific collection
 CMS.registerEventListener({
   name: 'postSave',
   collection: 'posts',
-  handler: ({ data: { entry } }) => {
-    // your code here
+  handler: ({ data, collection, field }) => {
+    // Your handler code
+  },
+});
+
+// Listen for all postSave events in a specific file in a collection
+CMS.registerEventListener({
+  name: 'postSave',
+  collection: 'settings',
+  file: 'global',
+  handler: ({ data, collection, field }) => {
+    // Your handler code
+  },
+});
+```
+
+## Pre Publish Event
+
+<Alert severity="info">Editorial Workflow ONLY</Alert>
+
+The `prePublish` event handler fires before the entry is "published", before the PR is merged into default branch.
+
+```javascript
+// Listen for ALL prePublish events
+CMS.registerEventListener({
+  name: 'prePublish',
+  handler: ({ data, collection, field }) => {
+    // Your handler code
+  },
+});
+
+// Listen for all prePublish events in a specific collection
+CMS.registerEventListener({
+  name: 'prePublish',
+  collection: 'posts',
+  handler: ({ data, collection, field }) => {
+    // Your handler code
+  },
+});
+
+// Listen for all prePublish events in a specific file in a collection
+CMS.registerEventListener({
+  name: 'prePublish',
+  collection: 'settings',
+  file: 'global',
+  handler: ({ data, collection, field }) => {
+    // Your handler code
+  },
+});
+```
+
+## Post Publish Event
+
+<Alert severity="info">Editorial Workflow ONLY</Alert>
+
+The `postPublish` event handler fires after the entry is "published", after the PR is merged into default branch.
+
+```javascript
+// Listen for ALL postPublish events
+CMS.registerEventListener({
+  name: 'postPublish',
+  handler: ({ data, collection, field }) => {
+    // Your handler code
+  },
+});
+
+// Listen for all postPublish events in a specific collection
+CMS.registerEventListener({
+  name: 'postPublish',
+  collection: 'posts',
+  handler: ({ data, collection, field }) => {
+    // Your handler code
+  },
+});
+
+// Listen for all postPublish events in a specific file in a collection
+CMS.registerEventListener({
+  name: 'postPublish',
+  collection: 'settings',
+  file: 'global',
+  handler: ({ data, collection, field }) => {
+    // Your handler code
   },
 });
 ```


### PR DESCRIPTION
Allow event handlers for `change`, `preSave`, `postSave`, `prePublish` and `postPublish` events to be registered without a collection specified (or even a field for `change`).

Addresses #970