### PR TITLE
docs: Update local-backend.mdx put the local_backend property in front of t…

### DIFF
--- a/packages/docs/content/docs/local-backend.mdx
+++ b/packages/docs/content/docs/local-backend.mdx
@@ -16,19 +16,20 @@ The local backend allows you to use Static CMS with a local git repository, inst
 
 <CodeTabs>
 ```yaml
-backend:
-  name: git-gateway
-
 # when using the default proxy server port
 local_backend: true
+
+backend:
+  name: git-gateway
 ```
 
 ```js
+// when using the default proxy server port
+local_backend: true,
+
 backend: {
   name: 'git-gateway',
 },
-// when using the default proxy server port
-local_backend: true,
 ```
 
 </CodeTabs>


### PR DESCRIPTION
See: https://github.com/StaticJsCMS/static-cms/issues/989#issuecomment-1816626741

It might be easier to understand that local_backend needs to be on top level and not inside the backend section.