### PR TITLE
docs: CDN Hosting use ^4.0.0

### DIFF
--- a/packages/docs/content/docs/add-to-your-site-cdn.mdx
+++ b/packages/docs/content/docs/add-to-your-site-cdn.mdx
@@ -45,12 +45,12 @@ In this example, we pull the `admin/index.html` file from a public CDN.
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="https://unpkg.com/@staticcms/app@^3.0.0/dist/main.css" />
+    <link rel="stylesheet" href="https://unpkg.com/@staticcms/app@^4.0.0/dist/main.css" />
     <title>Content Manager</title>
   </head>
   <body>
     <!-- Include the script that builds the page and powers Static CMS -->
-    <script src="https://unpkg.com/@staticcms/app@^3.0.0/dist/static-cms-app.js"></script>
+    <script src="https://unpkg.com/@staticcms/app@^4.0.0/dist/static-cms-app.js"></script>
     <script>
       window.CMS.init();
     </script>


### PR DESCRIPTION
The code block in https://www.staticcms.org/docs/add-to-your-site-cdn#app-file-structure was using the ^3.0.0 URL.

This PR updates it to ^4.0.0