### PR TITLE
feat: fallback to date-fns.parseISO when date cannot be parsed

### DIFF
--- a/packages/core/src/widgets/datetime/DateTimeControl.tsx
+++ b/packages/core/src/widgets/datetime/DateTimeControl.tsx
@@ -85,7 +85,7 @@ const DateTimeControl: FC<WidgetControlProps<string | Date, DateTimeField>> = ({
     if (storageFormat) {
       const parsed = parse(valueToParse, storageFormat, new Date());
       // if parsing fails, Invalid Date (NaN) will be returned: fallback to parseISO
-      if (!isNaN(parsed)) {
+      if (!isNaN(parsed.getTime())) {
         return parsed;
       }
     }

--- a/packages/core/src/widgets/datetime/DateTimeControl.tsx
+++ b/packages/core/src/widgets/datetime/DateTimeControl.tsx
@@ -82,7 +82,14 @@ const DateTimeControl: FC<WidgetControlProps<string | Date, DateTimeField>> = ({
       return valueToParse;
     }
 
-    return storageFormat ? parse(valueToParse, storageFormat, new Date()) : parseISO(valueToParse);
+    if (storageFormat) {
+      const parsed = parse(valueToParse, storageFormat, new Date());
+      // if parsing fails, Invalid Date (NaN) will be returned: fallback to parseISO
+      if (!isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return parseISO(valueToParse);
   }, [defaultValue, storageFormat, internalValue]);
 
   const handleChange = useCallback(


### PR DESCRIPTION
I am migrating a website from Decap/NetlifyCMS and I have an issue with existing dates not being parsed.

The dates are stored as `2024-02-25T18:30:00.000Z` (ISO format) and date-fns tries to parse it with the format `"yyyy-MM-dd'T'HH:mm:ssXXX"` (which does not raise an exception, but returns an Invalid Date): https://date-fns.org/v3.3.1/docs/parse

> If parsing failed, Invalid Date will be returned. Invalid Date is a Date, whose time value is NaN. Time value of Date: http://es5.github.io/#x15.9.1.1

I don't mind storing them with the static-cms default, however it would be nice if static-cms could try harder to parse the date (instead of showing an empty date, losing the data).