### PR TITLE
bug: glitch for {filters,groups}_default

### DIFF
--- a/packages/core/dev-test/config.yml
+++ b/packages/core/dev-test/config.yml
@@ -39,6 +39,7 @@ collections:
         field: title
     create: true
     view_filters:
+      default: posts-with-index
       filters:
         - name: posts-with-index
           label: Posts With Index
@@ -53,6 +54,7 @@ collections:
           field: draft
           pattern: true
     view_groups:
+      default: by-year
       groups:
         - name: by-year
           label: Year

--- a/packages/core/dev-test/data.js
+++ b/packages/core/dev-test/data.js
@@ -34,6 +34,10 @@ window.repoFiles = {
       content:
         '---\ntitle: This post should not appear because the extension is different\nimage: /assets/uploads/moby-dick.jpg\ndate: 2015-02-16T00:00:00.000Z\ndescription: YAML front matter post\ncategory: yaml\ntags:\n  - yaml---\n\n# I Am a Title in Markdown\n\nHello, world\n\n* One Thing\n* Another Thing\n* A Third Thing\n',
     },
+    '2015-02-15-this-is-post-number-2015.md': {
+      content:
+        '+++\ntitle = "This is post #2015"\nimage = "/assets/uploads/moby-dick.jpg"\ndate = "2015-02-15T00:00:00.000Z"\n+++\n\n# I Am a Title in Markdown\n\nHello, world\n\n* One Thing\n* Another Thing\n* A Third Thing\n',
+    },
   },
   _faqs: {
     'what-is-static-cms.md': {

--- a/packages/demo/public/simple/config.yml
+++ b/packages/demo/public/simple/config.yml
@@ -38,6 +38,7 @@ collections:
         field: title
     create: true
     view_filters:
+      default: posts-with-index
       filters:
         - name: posts-with-index
           label: Posts With Index
@@ -48,6 +49,7 @@ collections:
           field: title
           pattern: front matter post
     view_groups:
+      default: by-year
       groups:
         - name: by-year
           label: Year

--- a/packages/demo/src/data.js
+++ b/packages/demo/src/data.js
@@ -34,6 +34,10 @@ window.repoFiles = {
       content:
         '---\ntitle: This post should not appear because the extension is different\nimage: /assets/uploads/moby-dick.jpg\ndate: 2015-02-16T00:00:00.000Z\n---\n\n# I Am a Title in Markdown\n\nHello, world\n\n* One Thing\n* Another Thing\n* A Third Thing\n',
     },
+    '2015-02-15-this-is-post-number-2015.md': {
+      content:
+        '+++\ntitle = "This is post #2015"\nimage = "/assets/uploads/moby-dick.jpg"\ndate = "2015-02-15T00:00:00.000Z"\n+++\n\n# I Am a Title in Markdown\n\nHello, world\n\n* One Thing\n* Another Thing\n* A Third Thing\n',
+    },
   },
   _faqs: {
     'what-is-static-cms.md': {


### PR DESCRIPTION
I just noticed a glitch when using `groups_default`:
- visit the [demo site](https://deploy-preview-1082.demo.staticcms.org/simple/#/collections/posts)
- look the `Posts` page: the default group should be selected
- switch to `FAQ`
- switch back to `Posts`: the default group is not selected anymore

I tried to fiddle with the code, but my knwoledge there is far too limited (I only saw that React was loading the `CollectionView` more than 100 times...)