### PR TITLE
feat: Support custom auth schemes for Github API

### DIFF
--- a/packages/core/src/backends/github/API.ts
+++ b/packages/core/src/backends/github/API.ts
@@ -33,7 +33,7 @@ import {
 } from '@staticcms/core/lib/util/APIUtils';
 import { GitHubCommitStatusState, PullRequestState } from './types';
 
-import type { DataFile, PersistOptions, UnpublishedEntry } from '@staticcms/core';
+import type { AuthScheme, DataFile, PersistOptions, UnpublishedEntry } from '@staticcms/core';
 import type { ApiRequest, FetchError } from '@staticcms/core/lib/util';
 import type AssetProxy from '@staticcms/core/valueObjects/AssetProxy';
 import type { Semaphore } from 'semaphore';
@@ -75,6 +75,7 @@ export const MOCK_PULL_REQUEST = -1;
 export interface Config {
   apiRoot?: string;
   token?: string;
+  authScheme?: AuthScheme;
   branch?: string;
   useOpenAuthoring?: boolean;
   openAuthoringEnabled?: boolean;
@@ -162,6 +163,7 @@ export type Diff = {
 export default class API {
   apiRoot: string;
   token: string;
+  authScheme: AuthScheme;
   branch: string;
   useOpenAuthoring?: boolean;
   openAuthoringEnabled?: boolean;
@@ -185,6 +187,7 @@ export default class API {
   constructor(config: Config) {
     this.apiRoot = config.apiRoot || 'https://api.github.com';
     this.token = config.token || '';
+    this.authScheme = config.authScheme || 'token';
     this.branch = config.branch || 'main';
     this.useOpenAuthoring = config.useOpenAuthoring;
     this.repo = config.repo || '';
@@ -242,7 +245,7 @@ export default class API {
     };
 
     if (this.token) {
-      baseHeader.Authorization = `token ${this.token}`;
+      baseHeader.Authorization = `${this.authScheme} ${this.token}`;
       return Promise.resolve(baseHeader);
     }
 

--- a/packages/core/src/backends/github/__tests__/API.spec.ts
+++ b/packages/core/src/backends/github/__tests__/API.spec.ts
@@ -103,6 +103,35 @@ describe('github API', () => {
       });
     });
 
+    it('should fetch url with authorization header using custom auth scheme', async () => {
+      const api = new API({
+        branch: 'gh-pages',
+        repo: 'my-repo',
+        token: 'token',
+        authScheme: 'Bearer',
+        squashMerges: false,
+        initialWorkflowStatus: WorkflowStatus.DRAFT,
+        cmsLabelPrefix: '',
+      });
+
+      fetch.mockResolvedValue({
+        text: jest.fn().mockResolvedValue('some response'),
+        ok: true,
+        status: 200,
+        headers: { get: () => '' },
+      });
+      const result = await api.request('/some-path');
+      expect(result).toEqual('some response');
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith('https://api.github.com/some-path', {
+        cache: 'no-cache',
+        headers: {
+          Authorization: 'Bearer token',
+          'Content-Type': 'application/json; charset=utf-8',
+        },
+      });
+    });
+
     it('should throw error on not ok response', async () => {
       const api = new API({
         branch: 'gh-pages',

--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -698,6 +698,8 @@ export interface SelectWidgetOptionObject {
 
 export type AuthScope = 'repo' | 'public_repo';
 
+export type AuthScheme = 'token' | 'Bearer';
+
 export type SlugEncoding = 'unicode' | 'ascii';
 
 export type RenderedField<F extends BaseField = UnknownField> = F & {
@@ -1025,6 +1027,7 @@ export interface Backend {
   identity_url?: string;
   gateway_url?: string;
   auth_scope?: AuthScope;
+  auth_scheme?: AuthScheme;
   commit_messages?: {
     create?: string;
     update?: string;


### PR DESCRIPTION
## Background

When looking to support custom authentication with Github (by proxying to Github API through a custom authenticated API), the `token` auth-scheme in the Authorization header may not be appropriate. 

For example, when looking to use AWS Lambda function to proxy Github API requests and using AWS Cognito for authentication (Cognito is the user management service offered by AWS out of the box), authenticated requests to the Lambda function must use `Bearer` scheme.

Note: Github API does seem to accept either `Bearer` or `token`, and even appears to prefer and sometimes mandate `Bearer` according to their API docs:
https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28#about-authentication

However - changing this would be a potentially breaking change and I'm hesitant to change something fundamental to the Github backend implementation in this PR. This PR would allow us to test that the normal Github implementation works with the `Bearer` scheme and change that to the new default in future (if desired) - but that's well outside the scope of this change.

# Changes

1. Allow configuring the `authScheme` used in `Authorization` headers for Github backend, defaulting to the expected default value of `token`.
2. Add basic test ensuring that overriding `authScheme` works for API spec. No equivalent tests exist in implementation spec so I haven't added equivalent tests for that.